### PR TITLE
Configurable Actuator endpoint & VM args - Maven Home/Binary separate configurations - Minor Fix in EcosystemManager - Shutdown endpoint enabled

### DIFF
--- a/trampoline/src/main/java/org/ernest/applications/trampoline/controller/HomeController.java
+++ b/trampoline/src/main/java/org/ernest/applications/trampoline/controller/HomeController.java
@@ -50,8 +50,11 @@ public class HomeController {
 	
 	@RequestMapping(value= "/setnewmicroservice", method = RequestMethod.POST)
 	@ResponseBody
-    public void setNewMicroservice(@RequestParam(value="name") String name, @RequestParam(value="pomLocation") String pomLocation, @RequestParam(value="defaultPort") String defaultPort, @RequestParam(value="actuatorPrefix") String actuatorPrefix) throws CreatingSettingsFolderException, ReadingEcosystemException, CreatingMicroserviceScriptException, SavingEcosystemException {
-		ecosystemManager.setNewMicroservice(name, pomLocation, defaultPort, actuatorPrefix);
+    public void setNewMicroservice(@RequestParam(value="name") String name, @RequestParam(value="pomLocation") String pomLocation, 
+    		@RequestParam(value="defaultPort") String defaultPort, @RequestParam(value="actuatorPrefix") String actuatorPrefix, 
+    		@RequestParam(value="vmArguments") String vmArguments) 
+    				throws CreatingSettingsFolderException, ReadingEcosystemException, CreatingMicroserviceScriptException, SavingEcosystemException {
+		ecosystemManager.setNewMicroservice(name, pomLocation, defaultPort, actuatorPrefix, vmArguments);
     }
 	
 	@RequestMapping(value= "/removemicroservice", method = RequestMethod.POST)
@@ -62,8 +65,8 @@ public class HomeController {
 	
 	@RequestMapping(value= "/startinstance", method = RequestMethod.POST)
 	@ResponseBody
-    public void startInstance(@RequestParam(value="id") String id, @RequestParam(value="port") String port) throws CreatingSettingsFolderException, ReadingEcosystemException, RunningMicroserviceScriptException, SavingEcosystemException {
-		ecosystemManager.startInstance(id, port);
+    public void startInstance(@RequestParam(value="id") String id, @RequestParam(value="port") String port, @RequestParam(value="vmArguments") String vmArguments) throws CreatingSettingsFolderException, ReadingEcosystemException, RunningMicroserviceScriptException, SavingEcosystemException {
+		ecosystemManager.startInstance(id, port, vmArguments);
     }
 	
 	@RequestMapping(value= "/health", method = RequestMethod.POST)

--- a/trampoline/src/main/java/org/ernest/applications/trampoline/controller/HomeController.java
+++ b/trampoline/src/main/java/org/ernest/applications/trampoline/controller/HomeController.java
@@ -31,7 +31,7 @@ public class HomeController {
 		model.addAttribute("instances", ecosystem.getInstances());
 		model.addAttribute("mavenBinaryLocation", ecosystem.getMavenBinaryLocation());
 		model.addAttribute("mavenHomeLocation", ecosystem.getMavenHomeLocation());
-		model.addAttribute("mavenBinaryLocationMessage", ecosystem.getMavenBinaryLocation() == null ? "Please set maven Binary Location. Ex: /Users/ernest/Documents/workspace/tools/apache-maven-3.2.1" : ecosystem.getMavenBinaryLocation());
+		model.addAttribute("mavenBinaryLocationMessage", ecosystem.getMavenBinaryLocation() == null ? "Set Maven Binary Location if necessary. Otherwise it will automatically be searched in a bin folder inside your Maven Home Location" : ecosystem.getMavenBinaryLocation());
 		model.addAttribute("mavenHomeLocationMessage", ecosystem.getMavenHomeLocation() == null ? "Please set maven Home Location. Ex: /Users/ernest/Documents/workspace/tools/apache-maven-3.2.1" : ecosystem.getMavenHomeLocation());
 		return HOME_VIEW;
     }

--- a/trampoline/src/main/java/org/ernest/applications/trampoline/controller/HomeController.java
+++ b/trampoline/src/main/java/org/ernest/applications/trampoline/controller/HomeController.java
@@ -29,21 +29,29 @@ public class HomeController {
 		Ecosystem ecosystem = ecosystemManager.getEcosystem();
 		model.addAttribute("microservices", ecosystem.getMicroservices());
 		model.addAttribute("instances", ecosystem.getInstances());
-		model.addAttribute("mavenLocation", ecosystem.getMavenLocation());
-		model.addAttribute("mavenLocationMessage", ecosystem.getMavenLocation() == null ? "Please set maven Location. Ex: /Users/ernest/Documents/workspace/tools/apache-maven-3.2.1" : ecosystem.getMavenLocation());
+		model.addAttribute("mavenBinaryLocation", ecosystem.getMavenBinaryLocation());
+		model.addAttribute("mavenHomeLocation", ecosystem.getMavenHomeLocation());
+		model.addAttribute("mavenBinaryLocationMessage", ecosystem.getMavenBinaryLocation() == null ? "Please set maven Binary Location. Ex: /Users/ernest/Documents/workspace/tools/apache-maven-3.2.1" : ecosystem.getMavenBinaryLocation());
+		model.addAttribute("mavenHomeLocationMessage", ecosystem.getMavenHomeLocation() == null ? "Please set maven Home Location. Ex: /Users/ernest/Documents/workspace/tools/apache-maven-3.2.1" : ecosystem.getMavenHomeLocation());
 		return HOME_VIEW;
     }
 	
-	@RequestMapping(value= "/setmavenlocation", method = RequestMethod.POST)
+	@RequestMapping(value= "/setmavenbinarylocation", method = RequestMethod.POST)
 	@ResponseBody
-    public void setMavenLocation(@RequestParam(value="path") String path) throws CreatingSettingsFolderException, ReadingEcosystemException, SavingEcosystemException {
-		ecosystemManager.setMavenLocation(path);
+    public void setMavenBinaryLocation(@RequestParam(value="path") String path) throws CreatingSettingsFolderException, ReadingEcosystemException, SavingEcosystemException {
+		ecosystemManager.setMavenBinaryLocation(path);
+    }
+	
+	@RequestMapping(value= "/setmavenhomelocation", method = RequestMethod.POST)
+	@ResponseBody
+    public void setMavenHomeLocation(@RequestParam(value="path") String path) throws CreatingSettingsFolderException, ReadingEcosystemException, SavingEcosystemException {
+		ecosystemManager.setMavenHomeLocation(path);
     }
 	
 	@RequestMapping(value= "/setnewmicroservice", method = RequestMethod.POST)
 	@ResponseBody
-    public void setNewMicroservice(@RequestParam(value="name") String name, @RequestParam(value="pomLocation") String pomLocation, @RequestParam(value="defaultPort") String defaultPort) throws CreatingSettingsFolderException, ReadingEcosystemException, CreatingMicroserviceScriptException, SavingEcosystemException {
-		ecosystemManager.setNewMicroservice(name, pomLocation, defaultPort);
+    public void setNewMicroservice(@RequestParam(value="name") String name, @RequestParam(value="pomLocation") String pomLocation, @RequestParam(value="defaultPort") String defaultPort, @RequestParam(value="actuatorPrefix") String actuatorPrefix) throws CreatingSettingsFolderException, ReadingEcosystemException, CreatingMicroserviceScriptException, SavingEcosystemException {
+		ecosystemManager.setNewMicroservice(name, pomLocation, defaultPort, actuatorPrefix);
     }
 	
 	@RequestMapping(value= "/removemicroservice", method = RequestMethod.POST)

--- a/trampoline/src/main/java/org/ernest/applications/trampoline/entities/Ecosystem.java
+++ b/trampoline/src/main/java/org/ernest/applications/trampoline/entities/Ecosystem.java
@@ -5,7 +5,8 @@ import java.util.List;
 
 public class Ecosystem {
 
-	private String mavenLocation;
+	private String mavenBinaryLocation;
+	private String mavenHomeLocation;
 	private List<Microservice> microservices;
 	private List<Instance> instances;
 	
@@ -14,14 +15,22 @@ public class Ecosystem {
 		instances = new ArrayList<Instance>();
 	}
 
-	public String getMavenLocation() {
-		return mavenLocation;
+	public String getMavenBinaryLocation() {
+		return mavenBinaryLocation;
 	}
-	
-	public void setMavenLocation(String mavenLocation) {
-		this.mavenLocation = mavenLocation;
+
+	public void setMavenBinaryLocation(String mavenBinaryLocation) {
+		this.mavenBinaryLocation = mavenBinaryLocation;
 	}
-	
+
+	public String getMavenHomeLocation() {
+		return mavenHomeLocation;
+	}
+
+	public void setMavenHomeLocation(String mavenHomeLocation) {
+		this.mavenHomeLocation = mavenHomeLocation;
+	}
+
 	public List<Microservice> getMicroservices() {
 		return microservices;
 	}

--- a/trampoline/src/main/java/org/ernest/applications/trampoline/entities/Instance.java
+++ b/trampoline/src/main/java/org/ernest/applications/trampoline/entities/Instance.java
@@ -7,6 +7,7 @@ public class Instance {
 	private String pomLocation;
 	private String port;
 	private String actuatorPrefix;
+	private String vmArguments;
 	
 	public String getId() {
 		return id;
@@ -38,4 +39,11 @@ public class Instance {
 	public void setActuatorPrefix(String actuatorPrefix) {
 		this.actuatorPrefix = actuatorPrefix;
 	}
+	public String getVmArguments() {
+		return vmArguments;
+	}
+	public void setVmArguments(String vmArguments) {
+		this.vmArguments = vmArguments;
+	}
+	
 }

--- a/trampoline/src/main/java/org/ernest/applications/trampoline/entities/Instance.java
+++ b/trampoline/src/main/java/org/ernest/applications/trampoline/entities/Instance.java
@@ -6,6 +6,7 @@ public class Instance {
 	private String name;
 	private String pomLocation;
 	private String port;
+	private String actuatorPrefix;
 	
 	public String getId() {
 		return id;
@@ -30,5 +31,11 @@ public class Instance {
 	}
 	public void setPort(String port) {
 		this.port = port;
+	}
+	public String getActuatorPrefix() {
+		return actuatorPrefix;
+	}
+	public void setActuatorPrefix(String actuatorPrefix) {
+		this.actuatorPrefix = actuatorPrefix;
 	}
 }

--- a/trampoline/src/main/java/org/ernest/applications/trampoline/entities/Microservice.java
+++ b/trampoline/src/main/java/org/ernest/applications/trampoline/entities/Microservice.java
@@ -6,6 +6,7 @@ public class Microservice {
 	private String name;
 	private String pomLocation;
 	private String defaultPort;
+	private String actuatorPrefix;
 	
 	public String getId() {
 		return id;
@@ -30,5 +31,11 @@ public class Microservice {
 	}
 	public void setDefaultPort(String defaultPort) {
 		this.defaultPort = defaultPort;
+	}
+	public String getActuatorPrefix() {
+		return actuatorPrefix;
+	}
+	public void setActuatorPrefix(String actuatorPrefix) {
+		this.actuatorPrefix = actuatorPrefix;
 	}
 }

--- a/trampoline/src/main/java/org/ernest/applications/trampoline/entities/Microservice.java
+++ b/trampoline/src/main/java/org/ernest/applications/trampoline/entities/Microservice.java
@@ -7,6 +7,7 @@ public class Microservice {
 	private String pomLocation;
 	private String defaultPort;
 	private String actuatorPrefix;
+	private String vmArguments;
 	
 	public String getId() {
 		return id;
@@ -34,6 +35,12 @@ public class Microservice {
 	}
 	public String getActuatorPrefix() {
 		return actuatorPrefix;
+	}
+	public String getVmArguments() {
+		return vmArguments;
+	}
+	public void setVmArguments(String vmArguments) {
+		this.vmArguments = vmArguments;
 	}
 	public void setActuatorPrefix(String actuatorPrefix) {
 		this.actuatorPrefix = actuatorPrefix;

--- a/trampoline/src/main/java/org/ernest/applications/trampoline/services/EcosystemManager.java
+++ b/trampoline/src/main/java/org/ernest/applications/trampoline/services/EcosystemManager.java
@@ -40,7 +40,7 @@ public class EcosystemManager {
 		fileManager.saveEcosystem(ecosystem);
 	}
 	
-	public void setNewMicroservice(String name, String pomLocation, String defaultPort, String actuatorPrefix) throws CreatingSettingsFolderException, ReadingEcosystemException, CreatingMicroserviceScriptException, SavingEcosystemException {
+	public void setNewMicroservice(String name, String pomLocation, String defaultPort, String actuatorPrefix, String vmArguments) throws CreatingSettingsFolderException, ReadingEcosystemException, CreatingMicroserviceScriptException, SavingEcosystemException {
 		Ecosystem ecosystem = fileManager.getEcosystem();
 		
 		Microservice microservice = new Microservice();
@@ -49,7 +49,8 @@ public class EcosystemManager {
 		microservice.setPomLocation(pomLocation);
 		microservice.setDefaultPort(defaultPort);
 		microservice.setActuatorPrefix(actuatorPrefix);
-		fileManager.createScript(microservice.getId(), pomLocation);
+		microservice.setVmArguments(vmArguments);
+		fileManager.createScript(microservice.getId(), pomLocation, microservice.getVmArguments());
 		
 		ecosystem.getMicroservices().add(microservice);
 		fileManager.saveEcosystem(ecosystem);
@@ -61,7 +62,7 @@ public class EcosystemManager {
 		fileManager.saveEcosystem(ecosystem);
 	}
 
-	public void startInstance(String id, String port) throws CreatingSettingsFolderException, ReadingEcosystemException, RunningMicroserviceScriptException, SavingEcosystemException{
+	public void startInstance(String id, String port, String vmArguments) throws CreatingSettingsFolderException, ReadingEcosystemException, RunningMicroserviceScriptException, SavingEcosystemException{
 		Ecosystem ecosystem = fileManager.getEcosystem();
 		
 		Microservice microservice = ecosystem.getMicroservices().stream().filter(m -> m.getId().equals(id)).collect(Collectors.toList()).get(0);
@@ -73,6 +74,7 @@ public class EcosystemManager {
 		instance.setName(microservice.getName());
 		instance.setPomLocation(microservice.getPomLocation());
 		instance.setActuatorPrefix(microservice.getActuatorPrefix());
+		instance.setVmArguments(vmArguments);
 		ecosystem.getInstances().add(instance);
 		fileManager.saveEcosystem(ecosystem);
 	}

--- a/trampoline/src/main/java/org/ernest/applications/trampoline/services/EcosystemManager.java
+++ b/trampoline/src/main/java/org/ernest/applications/trampoline/services/EcosystemManager.java
@@ -50,7 +50,7 @@ public class EcosystemManager {
 		microservice.setDefaultPort(defaultPort);
 		microservice.setActuatorPrefix(actuatorPrefix);
 		microservice.setVmArguments(vmArguments);
-		fileManager.createScript(microservice.getId(), pomLocation, microservice.getVmArguments());
+		fileManager.createScript(microservice.getId(), pomLocation);
 		
 		ecosystem.getMicroservices().add(microservice);
 		fileManager.saveEcosystem(ecosystem);
@@ -66,7 +66,7 @@ public class EcosystemManager {
 		Ecosystem ecosystem = fileManager.getEcosystem();
 		
 		Microservice microservice = ecosystem.getMicroservices().stream().filter(m -> m.getId().equals(id)).collect(Collectors.toList()).get(0);
-		fileManager.runScript(microservice.getId(), ecosystem.getMavenBinaryLocation(), ecosystem.getMavenHomeLocation(), port);
+		fileManager.runScript(microservice.getId(), ecosystem.getMavenBinaryLocation(), ecosystem.getMavenHomeLocation(), port, vmArguments);
 		
 		Instance instance = new Instance();
 		instance.setId(UUID.randomUUID().toString());

--- a/trampoline/src/main/java/org/ernest/applications/trampoline/services/EcosystemManager.java
+++ b/trampoline/src/main/java/org/ernest/applications/trampoline/services/EcosystemManager.java
@@ -1,5 +1,6 @@
 package org.ernest.applications.trampoline.services;
 
+import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -27,13 +28,19 @@ public class EcosystemManager {
 		return fileManager.getEcosystem();
 	}
 	
-	public void setMavenLocation(String path) throws CreatingSettingsFolderException, ReadingEcosystemException, SavingEcosystemException {
+	public void setMavenBinaryLocation(String path) throws CreatingSettingsFolderException, ReadingEcosystemException, SavingEcosystemException {
 		Ecosystem ecosystem = fileManager.getEcosystem();
-		ecosystem.setMavenLocation(path);
+		ecosystem.setMavenBinaryLocation(path);
 		fileManager.saveEcosystem(ecosystem);
 	}
 	
-	public void setNewMicroservice(String name, String pomLocation, String defaultPort) throws CreatingSettingsFolderException, ReadingEcosystemException, CreatingMicroserviceScriptException, SavingEcosystemException {
+	public void setMavenHomeLocation(String path) throws CreatingSettingsFolderException, ReadingEcosystemException, SavingEcosystemException {
+		Ecosystem ecosystem = fileManager.getEcosystem();
+		ecosystem.setMavenHomeLocation(path);
+		fileManager.saveEcosystem(ecosystem);
+	}
+	
+	public void setNewMicroservice(String name, String pomLocation, String defaultPort, String actuatorPrefix) throws CreatingSettingsFolderException, ReadingEcosystemException, CreatingMicroserviceScriptException, SavingEcosystemException {
 		Ecosystem ecosystem = fileManager.getEcosystem();
 		
 		Microservice microservice = new Microservice();
@@ -41,6 +48,7 @@ public class EcosystemManager {
 		microservice.setName(name);
 		microservice.setPomLocation(pomLocation);
 		microservice.setDefaultPort(defaultPort);
+		microservice.setActuatorPrefix(actuatorPrefix);
 		fileManager.createScript(microservice.getId(), pomLocation);
 		
 		ecosystem.getMicroservices().add(microservice);
@@ -57,13 +65,14 @@ public class EcosystemManager {
 		Ecosystem ecosystem = fileManager.getEcosystem();
 		
 		Microservice microservice = ecosystem.getMicroservices().stream().filter(m -> m.getId().equals(id)).collect(Collectors.toList()).get(0);
-		fileManager.runScript(microservice.getId(), ecosystem.getMavenLocation(), port);
+		fileManager.runScript(microservice.getId(), ecosystem.getMavenBinaryLocation(), ecosystem.getMavenHomeLocation(), port);
 		
 		Instance instance = new Instance();
 		instance.setId(UUID.randomUUID().toString());
 		instance.setPort(port);
 		instance.setName(microservice.getName());
 		instance.setPomLocation(microservice.getPomLocation());
+		instance.setActuatorPrefix(microservice.getActuatorPrefix());
 		ecosystem.getInstances().add(instance);
 		fileManager.saveEcosystem(ecosystem);
 	}
@@ -73,7 +82,7 @@ public class EcosystemManager {
 		Instance instance = ecosystem.getInstances().stream().filter(i -> i.getId().equals(id)).collect(Collectors.toList()).get(0);
 		
 		try {
-			new ClientRequest("http://localhost:" + instance.getPort() + "/shutdown").post(String.class);
+			new ClientRequest("http://localhost:" + instance.getPort() + instance.getActuatorPrefix() + "/shutdown").post(String.class);
 		} catch (Exception e) {
 			e.printStackTrace();
 			throw new ShuttingDownInstanceException();
@@ -85,8 +94,8 @@ public class EcosystemManager {
 
 	public String getStatusInstance(String id) throws CreatingSettingsFolderException, ReadingEcosystemException {
 		Ecosystem ecosystem = fileManager.getEcosystem();
-		Instance instance = ecosystem.getInstances().stream().filter(i -> i.getId().equals(id)).collect(Collectors.toList()).get(0);
-		if(isDeployed(instance)){
+		List<Instance> instances = ecosystem.getInstances().stream().filter(i -> i.getId().equals(id)).collect(Collectors.toList());
+		if(!instances.isEmpty() && isDeployed(instances.get(0))){
 			return StatusInstance.DEPLOYED.getCode();
 		}
 		return StatusInstance.NOT_DEPLOYED.getCode();
@@ -100,7 +109,7 @@ public class EcosystemManager {
 
 	private boolean isDeployed(Instance instance) {
 		try{
-			new ClientRequest("http://localhost:" + instance.getPort() + "/env").get(String.class);
+			new ClientRequest("http://localhost:" + instance.getPort() + instance.getActuatorPrefix() + "/env").get(String.class);
 		}catch(Exception e){
 			return false;
 		}

--- a/trampoline/src/main/java/org/ernest/applications/trampoline/services/FileManager.java
+++ b/trampoline/src/main/java/org/ernest/applications/trampoline/services/FileManager.java
@@ -74,13 +74,14 @@ public class FileManager {
 		}
 	}
 
-	public void createScript(String id, String pomLocation) throws CreatingMicroserviceScriptException {
+	public void createScript(String id, String pomLocation, String vmArguments) throws CreatingMicroserviceScriptException {
 		try {
 			if(System.getProperties().getProperty("os.name").contains("Windows")){
-				FileUtils.writeStringToFile(new File(getSettingsFolder() +"/"+ id +".txt"), "cd " + pomLocation + " && mvn spring-boot:run -Dserver.port=#port");
+				FileUtils.writeStringToFile(new File(getSettingsFolder() +"/"+ id +".txt"), "cd " + pomLocation + " && mvn spring-boot:run -Dserver.port=#port " + vmArguments);
 			}else{
 				FileUtils.writeStringToFile(new File(getSettingsFolder() +"/"+ id +".sh"), 
-						"export M2_HOME=$1; export PATH=$PATH:$2; cd " + pomLocation + "; mvn spring-boot:run -Dserver.port=$3; -Dendpoints.shutdown.enabled=true");
+						"export M2_HOME=$1; export PATH=$PATH:$2; cd " + pomLocation + "; mvn spring-boot:run -Dserver.port=$3 "
+						+ "-Dendpoints.shutdown.enabled=true -Dmanagement.security.enabled=false " + vmArguments);
 			}
 		} catch (IOException e) {
 			e.printStackTrace();

--- a/trampoline/src/main/java/org/ernest/applications/trampoline/services/FileManager.java
+++ b/trampoline/src/main/java/org/ernest/applications/trampoline/services/FileManager.java
@@ -53,17 +53,19 @@ public class FileManager {
 		}
 	}
 
-	public void runScript(String id, String mavenLocation, String port) throws RunningMicroserviceScriptException {
-		System.out.println(mavenLocation + " " + port);
+	public void runScript(String id, String mavenBinaryLocation, String mavenHomeLocation, String port) throws RunningMicroserviceScriptException {
+		System.out.println(mavenBinaryLocation + " " + port);
 		try {
 			if(System.getProperties().getProperty("os.name").contains("Windows")){
 				String commands = FileUtils.readFileToString(new File(getSettingsFolder() +"/"+ id +".txt"));
-				commands = commands.replaceAll("#mavenLocation", mavenLocation);
+				commands = commands.replaceAll("#mavenBinaryLocation", mavenBinaryLocation);
+				commands = commands.replaceAll("#mavenHomeLocation", mavenBinaryLocation);
 				commands = commands.replaceAll("#port", port);
 				Runtime.getRuntime().exec("cmd /c start cmd.exe /K \""+commands+"\"");
 
 			}else{
-				new ProcessBuilder("sh", getSettingsFolder() + "/" + id + ".sh", mavenLocation, port).start();
+				mavenBinaryLocation = (mavenBinaryLocation != null && mavenBinaryLocation.trim().length() > 0) ? mavenBinaryLocation: mavenHomeLocation + "/bin";
+				new ProcessBuilder("sh", getSettingsFolder() + "/" + id + ".sh", mavenHomeLocation, mavenBinaryLocation, port).start();
 			}
 			
 		} catch (IOException e) {
@@ -75,9 +77,10 @@ public class FileManager {
 	public void createScript(String id, String pomLocation) throws CreatingMicroserviceScriptException {
 		try {
 			if(System.getProperties().getProperty("os.name").contains("Windows")){
-				FileUtils.writeStringToFile(new File(getSettingsFolder() +"/"+ id +".txt"), "cd C:\\Users\\Ernest\\Documents\\GitHub\\Trampoline\\microservice-example && mvn spring-boot:run -Dserver.port=#port");
+				FileUtils.writeStringToFile(new File(getSettingsFolder() +"/"+ id +".txt"), "cd " + pomLocation + " && mvn spring-boot:run -Dserver.port=#port");
 			}else{
-				FileUtils.writeStringToFile(new File(getSettingsFolder() +"/"+ id +".sh"), "export M2_HOME=$1; export PATH=$PATH:$M2_HOME/bin; cd " + pomLocation + "; mvn spring-boot:run -Dserver.port=$2;");
+				FileUtils.writeStringToFile(new File(getSettingsFolder() +"/"+ id +".sh"), 
+						"export M2_HOME=$1; export PATH=$PATH:$2; cd " + pomLocation + "; mvn spring-boot:run -Dserver.port=$3; -Dendpoints.shutdown.enabled=true");
 			}
 		} catch (IOException e) {
 			e.printStackTrace();

--- a/trampoline/src/main/java/org/ernest/applications/trampoline/services/FileManager.java
+++ b/trampoline/src/main/java/org/ernest/applications/trampoline/services/FileManager.java
@@ -76,13 +76,9 @@ public class FileManager {
 
 	public void createScript(String id, String pomLocation, String vmArguments) throws CreatingMicroserviceScriptException {
 		try {
-			if(System.getProperties().getProperty("os.name").contains("Windows")){
-				FileUtils.writeStringToFile(new File(getSettingsFolder() +"/"+ id +".txt"), "cd " + pomLocation + " && mvn spring-boot:run -Dserver.port=#port " + vmArguments);
-			}else{
-				FileUtils.writeStringToFile(new File(getSettingsFolder() +"/"+ id +".sh"), 
-						"export M2_HOME=$1; export PATH=$PATH:$2; cd " + pomLocation + "; mvn spring-boot:run -Dserver.port=$3 "
-						+ "-Dendpoints.shutdown.enabled=true -Dmanagement.security.enabled=false " + vmArguments);
-			}
+			FileUtils.writeStringToFile(new File(getSettingsFolder() +"/"+ id +".sh"), 
+					"export M2_HOME=$1; export PATH=$PATH:$2; cd " + pomLocation + "; mvn spring-boot:run -Dserver.port=$3 "
+					+ "-Dendpoints.shutdown.enabled=true -Dmanagement.security.enabled=false " + vmArguments);
 		} catch (IOException e) {
 			e.printStackTrace();
 			throw new CreatingMicroserviceScriptException();

--- a/trampoline/src/main/resources/application.properties
+++ b/trampoline/src/main/resources/application.properties
@@ -2,3 +2,4 @@ settings.folder.path.linux=/home/#userName/Documents/trampoline
 settings.folder.path.mac=/Users/#userName/Documents/trampoline
 settings.folder.path.windows=C:/Temp/trampoline
 settings.file.name=settings.txt
+logging.level.org.springframework=DEBUG

--- a/trampoline/src/main/resources/static/js/backend.requests.js
+++ b/trampoline/src/main/resources/static/js/backend.requests.js
@@ -36,7 +36,8 @@ function setNewMicroservice(){
 			    url : "/setnewmicroservice",
 			    type: "POST",
 			    data : {name: $("#input-newmicroservice-name").val(), pomLocation: $("#input-newmicroservice-pomlocation").val(), defaultPort: $("#input-newmicroservice-defaultport").val(),
-			    	    actuatorPrefix: $("#input-newmicroservice-actuatorprefix").val()},
+			    	    actuatorPrefix: $("#input-newmicroservice-actuatorprefix").val(),
+			    	    vmArguments: $("#input-newmicroservice-vmarguments").val()},
 			    success: function(data, textStatus, jqXHR) { location.reload(); }
 			});
 		}
@@ -74,7 +75,7 @@ function startInstance(microserviceId){
 	$.ajax({
 	    url : "/startinstance",
 	    type: "POST",
-	    data : {id: microserviceId, port: $("#input-port-" + microserviceId).val()},
+	    data : {id: microserviceId, port: $("#input-port-" + microserviceId).val(), vmArguments: $("#input-vmarguments-" + microserviceId).val()},
 	    success: function(data, textStatus, jqXHR) { location.reload(); }
 	});
 }

--- a/trampoline/src/main/resources/static/js/backend.requests.js
+++ b/trampoline/src/main/resources/static/js/backend.requests.js
@@ -1,19 +1,32 @@
-function setMavenLocation(){
-	if($("#input-mavenlocation").val() == ''){
-		$("#form-group-mavenlocation").addClass("has-error");
+function setMavenBinaryLocation(){
+	if($("#input-mavenbinarylocation").val() == ''){
+		$("#form-group-mavenbinarylocation").addClass("has-error");
 	}else{
 		$.ajax({
-		    url : "/setmavenlocation",
+		    url : "/setmavenbinarylocation",
 		    type: "POST",
-		    data : {path: $("#input-mavenlocation").val()},
+		    data : {path: $("#input-mavenbinarylocation").val()},
+		    success: function(data, textStatus, jqXHR) { location.reload(); }
+		});
+	}
+}
+
+function setMavenHomeLocation(){
+	if($("#input-mavenhomelocation").val() == ''){
+		$("#form-group-mavenhomelocation").addClass("has-error");
+	}else{
+		$.ajax({
+		    url : "/setmavenhomelocation",
+		    type: "POST",
+		    data : {path: $("#input-mavenhomelocation").val()},
 		    success: function(data, textStatus, jqXHR) { location.reload(); }
 		});
 	}
 }
 
 function setNewMicroservice(){
-	if($("#input-hidden-mavenlocation").val() == ''){
-		$("#form-group-mavenlocation").addClass("has-error");
+	if($("#input-hidden-mavenbinarylocation").val() == ''){
+		$("#form-group-mavenbinarylocation").addClass("has-error");
 	}else{
 		cleaningNewMicroserviceFrom();
 		if($("#input-newmicroservice-name").val() == '' || $("#input-newmicroservice-pomlocation").val() == '' || $("#input-newmicroservice-defaultport").val() == ''){
@@ -22,7 +35,8 @@ function setNewMicroservice(){
 			$.ajax({
 			    url : "/setnewmicroservice",
 			    type: "POST",
-			    data : {name: $("#input-newmicroservice-name").val(), pomLocation: $("#input-newmicroservice-pomlocation").val(), defaultPort: $("#input-newmicroservice-defaultport").val()},
+			    data : {name: $("#input-newmicroservice-name").val(), pomLocation: $("#input-newmicroservice-pomlocation").val(), defaultPort: $("#input-newmicroservice-defaultport").val(),
+			    	    actuatorPrefix: $("#input-newmicroservice-actuatorprefix").val()},
 			    success: function(data, textStatus, jqXHR) { location.reload(); }
 			});
 		}

--- a/trampoline/src/main/resources/static/js/backend.requests.js
+++ b/trampoline/src/main/resources/static/js/backend.requests.js
@@ -25,8 +25,8 @@ function setMavenHomeLocation(){
 }
 
 function setNewMicroservice(){
-	if($("#input-hidden-mavenbinarylocation").val() == ''){
-		$("#form-group-mavenbinarylocation").addClass("has-error");
+	if($("#input-hidden-mavenhomelocation").val() == ''){
+		$("#form-group-mavenhomelocation").addClass("has-error");
 	}else{
 		cleaningNewMicroserviceFrom();
 		if($("#input-newmicroservice-name").val() == '' || $("#input-newmicroservice-pomlocation").val() == '' || $("#input-newmicroservice-defaultport").val() == ''){

--- a/trampoline/src/main/resources/templates/home.html
+++ b/trampoline/src/main/resources/templates/home.html
@@ -31,7 +31,8 @@ body {
 
 </head>
 <body>
-	<input type="hidden" th:value="${mavenLocation}" id="input-hidden-mavenlocation"/>
+	<input type="hidden" th:value="${mavenBinaryLocation}" id="input-hidden-mavenbinarylocation"/>
+	<input type="hidden" th:value="${mavenHomeLocation}" id="input-hidden-mavenhomelocation"/>
 	<div class="navbar-nav navbar-inverse navbar-fixed-top">
 		<div class="container">
 			<div class="navbar-header">
@@ -53,16 +54,27 @@ body {
 			<h4>
 				<strong>Trampoline Settings</strong>
 			</h4>
-			   <div class="form-group" id="form-group-mavenlocation">
-			    <label for="inputEmail3" class="col-sm-2 control-label">Maven Location</label>
+			  <div class="form-group" id="form-group-mavenhomelocation">
+			    <label for="inputEmail3" class="col-sm-2 control-label">Maven Home Location</label>
 			    <div class="col-sm-10">
-			      <input type="email" class="form-control" id="input-mavenlocation" th:placeholder="${mavenLocationMessage}"/>
+			      <input type="email" class="form-control" id="input-mavenhomelocation" th:placeholder="${mavenHomeLocationMessage}"/>
 			    </div>
 			  </div>
 			  <div class="form-group">
 			    <div class="col-sm-offset-2 col-sm-10">
-			      <button class="btn btn-default" onclick="setMavenLocation()">Set Maven Location</button>
+			      <button class="btn btn-default" onclick="setMavenHomeLocation()">Set Maven Home Location</button>
 			    </div>
+			   <div class="form-group" id="form-group-mavenbinarylocation">
+			    <label for="inputEmail3" class="col-sm-2 control-label">Maven Binary Location</label>
+			    <div class="col-sm-10">
+			      <input type="email" class="form-control" id="input-mavenbinarylocation" th:placeholder="${mavenBinaryLocationMessage}"/>
+			    </div>
+			  </div>
+			  <div class="form-group">
+			    <div class="col-sm-offset-2 col-sm-10">
+			      <button class="btn btn-default" onclick="setMavenBinaryLocation()">Set Maven Binary Location</button>
+			    </div>
+			  </div>
 			  </div>
 		</div>
 		<div class="row">
@@ -87,6 +99,12 @@ body {
 			      <input type="email" class="form-control" id="input-newmicroservice-defaultport" placeholder="9988"/>
 			    </div>
 			  </div>
+			  <div class="form-group" id="form-newmicroservice-actuatorprefix">
+			    <label for="inputEmail4" class="col-sm-2 control-label">Actuator Prefix</label>
+			    <div class="col-sm-10">
+			      <input type="email" class="form-control" id="input-newmicroservice-actuatorprefix" placeholder=""/>
+			    </div>
+			  </div>
 			  <div class="form-group">
 			    <div class="col-sm-offset-2 col-sm-10">
 			      <button class="btn btn-default" onclick="setNewMicroservice()">Create</button>
@@ -106,6 +124,7 @@ body {
 						<th>Name</th>
 						<th>Pom Location</th>
 						<th>Port</th>
+						<th>Actuator Prefix</th>
 						<th>Start</th>
 						<th>Remove</th>
 					</tr>
@@ -115,6 +134,7 @@ body {
 						<td th:text="${microservice.name}"></td>
 						<td th:text="${microservice.pomLocation}"></td>
 						<td class="center"><input type="email" class="form-control" th:value="${microservice.defaultPort}" th:id="'input-port-' + ${microservice.id}"/></td>
+						<td class="center"><input type="email" class="form-control" th:value="${microservice.actuatorPrefix}" th:id="'input-actuator-' + ${microservice.id}"/></td>
 						<td class="center"><button type="button" th:onclick="'startInstance(\'' + ${microservice.id} + '\')'" class="btn btn-primary btn-sm">Start</button></td>
 						<td class="center"><button type="button" th:onclick="'removeMicroservice(\'' + ${microservice.id} + '\')'" class="btn btn-danger btn-sm">Remove</button></td>
 					</tr>

--- a/trampoline/src/main/resources/templates/home.html
+++ b/trampoline/src/main/resources/templates/home.html
@@ -164,6 +164,7 @@ body {
 						<th>Name</th>
 						<th>Pom Location</th>
 						<th>Port</th>
+						<th>VM Arguments</th>
 						<th>Status</th>
 						<th>Kill</th>
 					</tr>
@@ -173,6 +174,7 @@ body {
 						<td th:text="${instance.name}"></td>
 						<td th:text="${instance.pomLocation}"></td>
 						<td class="center" th:text="${instance.port}"></td>
+						<td class="center" th:text="${instance.vmArguments}"></td>
 						<td class="center"><span class="label label-warning" th:id="'label-status-' + ${instance.id}">Waiting</span></td>
 						<td class="center"><button type="button" th:onclick="'killInstance(\'' + ${instance.id} + '\')'" class="btn btn-danger btn-sm">Kill</button></td>
 					</tr>

--- a/trampoline/src/main/resources/templates/home.html
+++ b/trampoline/src/main/resources/templates/home.html
@@ -105,6 +105,12 @@ body {
 			      <input type="email" class="form-control" id="input-newmicroservice-actuatorprefix" placeholder=""/>
 			    </div>
 			  </div>
+			  <div class="form-group" id="form-newmicroservice-vmarguments">
+			    <label for="inputEmail5" class="col-sm-2 control-label">VM Arguments</label>
+			    <div class="col-sm-10">
+			      <input type="email" class="form-control" id="input-newmicroservice-vmarguments" placeholder=""/>
+			    </div>
+			  </div>
 			  <div class="form-group">
 			    <div class="col-sm-offset-2 col-sm-10">
 			      <button class="btn btn-default" onclick="setNewMicroservice()">Create</button>
@@ -125,6 +131,7 @@ body {
 						<th>Pom Location</th>
 						<th>Port</th>
 						<th>Actuator Prefix</th>
+						<th>VM Arguments</th>
 						<th>Start</th>
 						<th>Remove</th>
 					</tr>
@@ -134,7 +141,8 @@ body {
 						<td th:text="${microservice.name}"></td>
 						<td th:text="${microservice.pomLocation}"></td>
 						<td class="center"><input type="email" class="form-control" th:value="${microservice.defaultPort}" th:id="'input-port-' + ${microservice.id}"/></td>
-						<td class="center"><input type="email" class="form-control" th:value="${microservice.actuatorPrefix}" th:id="'input-actuator-' + ${microservice.id}"/></td>
+						<td th:text="${microservice.actuatorPrefix}"></td>
+						<td class="center"><input type="email" class="form-control" th:value="${microservice.vmArguments}" th:id="'input-vmarguments-' + ${microservice.id}"/></td>
 						<td class="center"><button type="button" th:onclick="'startInstance(\'' + ${microservice.id} + '\')'" class="btn btn-primary btn-sm">Start</button></td>
 						<td class="center"><button type="button" th:onclick="'removeMicroservice(\'' + ${microservice.id} + '\')'" class="btn btn-danger btn-sm">Remove</button></td>
 					</tr>


### PR DESCRIPTION
Hi there, this PR addresses the following aspects:

1. **Configurable Actuator endpoint & VM args:** the current Trampoline only works when the actuator endpoint doesn't have a prefix (management.context-path). Thus the status update and the kill button don't work for those projects. Also in Spring microservices it's very usual that we need to set up VM arguments. Now we can do it.
2. **Maven Home/Binary separate configurations:** I am working with Ubuntu Linux. This distribution has its Maven Home in /usr/share/maven and its Maven Binary in /usr/bin. Now we can set up different Maven Home/Binary path. If the user doesn't specify the binary value it is derived from the Maven Home value -> MAVEN_HOME/bin
3. **Minor Fix in EcosystemManager**
4. **Shutdown endpoint enabled:** from Spring Boot 1.5+ endpoints such as /shutdown are secured by default. I have added a -Dmanagement.security.enabled=false flag.

I have tested this changes on Windows and Linux Ubuntu.