### PR TITLE
Spring DEBUG logging removed - corrected grammar

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -210,7 +210,7 @@
 									<img src="images/staff_4.jpg" alt="" class="img-responsive">
 									<h2>José Antonio Iñigo</h2>
 									<p class="role">Contributor</p>
-									<p>Software Architect on Profile. My main areas on interest are Cloud technologies (including microservices, reactive applications and data stream processing), DevOps and infrastructure automation.</p>
+									<p>Software Architect at Profile. My main areas on interest are Cloud technologies (including microservices, reactive applications and data stream processing), DevOps and infrastructure automation.</p>
 									<ul class="fh5co-social">
 										<li><a href="https://es.linkedin.com/in/jose-antonio-%C3%AD%C3%B1igo-garrido-65940947/en"><i class="icon-linkedin"></i></a></li>
 										<li><a href="https://stackoverflow.com/users/1729795/codependent">stack overflow</a></li>

--- a/trampoline/src/main/resources/application.properties
+++ b/trampoline/src/main/resources/application.properties
@@ -2,4 +2,3 @@ settings.folder.path.linux=/home/#userName/Documents/trampoline
 settings.folder.path.mac=/Users/#userName/Documents/trampoline
 settings.folder.path.windows=C:/Temp/trampoline
 settings.file.name=settings.txt
-logging.level.org.springframework=DEBUG


### PR DESCRIPTION
Hi Ernest,

a couple of minor changes:

- application.properties: removed `logging.level.org.springframework=DEBUG` that I used when working with the previous PR. Sorry about that.
- Corrected grammar on the team description.

Regards