### PR TITLE
actuator prefix in trace and metrics

### DIFF
--- a/trampoline/src/main/java/org/ernest/applications/trampoline/services/MetricsCollector.java
+++ b/trampoline/src/main/java/org/ernest/applications/trampoline/services/MetricsCollector.java
@@ -32,7 +32,7 @@ public class MetricsCollector {
 
         ecosystemManager.getEcosystem().getInstances().forEach(instance ->{
             try {
-                JSONObject metricsJson = new JSONObject(new RestTemplate().getForObject("http://127.0.0.1:" + instance.getPort() + "/metrics", String.class));
+                JSONObject metricsJson = new JSONObject(new RestTemplate().getForObject("http://127.0.0.1:" + instance.getPort() + instance.getActuatorPrefix() + "/metrics", String.class));
                 Metrics metrics = buildMetricsFromJsonResponse(metricsJson);
 
                 if (metricsMap.containsKey(instance.getId())) {

--- a/trampoline/src/main/java/org/ernest/applications/trampoline/services/TraceParser.java
+++ b/trampoline/src/main/java/org/ernest/applications/trampoline/services/TraceParser.java
@@ -28,7 +28,7 @@ public class TraceParser {
         List<TraceActuator> traces = new ArrayList<>();
 
         Instance instance = ecosystemManager.getEcosystem().getInstances().stream().filter(i -> i.getId().equals(idInstance)).findAny().get();
-        JSONArray traceArrayJson = new JSONArray(new RestTemplate().getForObject("http://127.0.0.1:" + instance.getPort() + "/trace", String.class));
+        JSONArray traceArrayJson = new JSONArray(new RestTemplate().getForObject("http://127.0.0.1:" + instance.getPort() + instance.getActuatorPrefix() + "/trace", String.class));
 
         for (int i = 0; i < traceArrayJson.length(); i++) {
             JSONObject traceJson = traceArrayJson.getJSONObject(i);


### PR DESCRIPTION
Just a minor fix: the trace and metrics rest calls didn't take into account the actuator prefix.

BTW, great idea to add this features.