### PR TITLE
Added restart button for instances

### DIFF
--- a/trampoline/src/main/java/org/ernest/applications/trampoline/controller/InstancesController.java
+++ b/trampoline/src/main/java/org/ernest/applications/trampoline/controller/InstancesController.java
@@ -64,6 +64,12 @@ public class InstancesController {
 		ecosystemManager.startInstance(id, port, vmArguments);
 	}
 
+	@RequestMapping(value= "/restartinstance", method = RequestMethod.POST)
+	@ResponseBody
+	public void restartInstance(@RequestParam(value="id") String id) throws CreatingSettingsFolderException, ReadingEcosystemException, SavingEcosystemException, ShuttingDownInstanceException {
+		ecosystemManager.restartInstance(id);
+	}
+
 	@RequestMapping(value= "/killinstance", method = RequestMethod.POST)
 	@ResponseBody
 	public void killInstance(@RequestParam(value="id") String id) throws CreatingSettingsFolderException, ReadingEcosystemException, SavingEcosystemException, ShuttingDownInstanceException {

--- a/trampoline/src/main/resources/static/v2/js/app/instances.js
+++ b/trampoline/src/main/resources/static/v2/js/app/instances.js
@@ -20,6 +20,20 @@ function startGroup(){
     }
 }
 
+function restartInstance(instanceId){
+    $('.front-loading').show();
+    $.ajax({
+        url : "/instances/restartinstance",
+        type: "POST",
+        data : {id: instanceId},
+        success: function(data, textStatus, jqXHR) { location.reload(); },
+        error: function (request, status, error) {
+            $('.front-loading').hide();
+            showNotification('danger', "Error occurred when trying to restart instance. Check Logs for more info");
+        }
+    });
+}
+
 function killInstance(instanceId){
     $('.front-loading').show();
 	$.ajax({

--- a/trampoline/src/main/resources/templates/instances.html
+++ b/trampoline/src/main/resources/templates/instances.html
@@ -156,6 +156,7 @@
                                         <th>Logs</th>
                                         <th>Trace</th>
                                         <th>Metrics</th>
+                                        <th>Restart</th>
                                         <th>Kill</th>
                                     </thead>
                                     <tbody>
@@ -168,6 +169,7 @@
                                             <td class="center"><button type="button" th:onclick="'window.open(\'http://localhost:'+${instance.port}+'/'+${instance.actuatorPrefix}+'/logfile\', \'_blank\');'" class="btn btn-primary btn-sm"><i class="fa fa-lg fa-clipboard" aria-hidden="true"></i></button></td>
                                             <td class="center"><button type="button" th:onclick="'showTraces(\'' + ${instance.id} + '\', \'' + ${instance.name} + '\', \'' + ${instance.port} + '\')'" class="btn btn-warning btn-sm"><i class="fa fa-lg fa-book" aria-hidden="true"></i></button></td>
                                             <td class="center"><button type="button" th:onclick="'showMetrics(\'' + ${instance.id} + '\', \'' + ${instance.name} + '\', \'' + ${instance.port} + '\')'" class="btn btn-info btn-sm"><i class="fa fa-lg fa-line-chart" aria-hidden="true"></i></button></td>
+                                            <td class="center"><button type="button" th:onclick="'restartInstance(\'' + ${instance.id} + '\')'" class="btn btn-danger btn-sm"><i class="fa fa-lg fa-undo" aria-hidden="true"></i></button></td>
                                             <td class="center"><button type="button" th:onclick="'killInstance(\'' + ${instance.id} + '\')'" class="btn btn-danger btn-sm"><i class="fa fa-lg fa-trash-o" aria-hidden="true"></i></button></td>
                                         </tr>
                                     </tbody>


### PR DESCRIPTION
It would be nice to have a simple way to restart instances on the fly without having to create a new one. This is especially helpful when they are launched from a group. @ErnestOrt Let me know if you approve/want any changes.