### PR TITLE
fixed git clone error

### DIFF
--- a/trampoline/src/main/java/org/ernest/applications/trampoline/services/GitManager.java
+++ b/trampoline/src/main/java/org/ernest/applications/trampoline/services/GitManager.java
@@ -93,7 +93,7 @@ public class GitManager {
         CloneCommand cloneCommand = Git.cloneRepository();
 
         if(ecosystem.getGitCredentials()!=null){
-            cloneCommand.setCredentialsProvider(buildCredentialsProvider(ecosystem.getGitCredentials())).call();
+            cloneCommand.setCredentialsProvider(buildCredentialsProvider(ecosystem.getGitCredentials()));
         }
         cloneCommand.setURI(gitUrl).setDirectory(new File(destinationFolder)).call();
     }


### PR DESCRIPTION
There was an error in git manager when issuing a command for git clone. It was initiating the clone command immediately after setting the credentials. However this should be done after credentials are set.