### PR TITLE
Added regex for cleaning up actuator prefix - fix for issue #74

### DIFF
--- a/trampoline/src/main/java/org/ernest/applications/trampoline/entities/Instance.java
+++ b/trampoline/src/main/java/org/ernest/applications/trampoline/entities/Instance.java
@@ -43,7 +43,7 @@ public class Instance {
 		this.port = port;
 	}
 	public String getActuatorPrefix() {
-		return actuatorPrefix;
+		return actuatorPrefix.replaceFirst("^/","");
 	}
 	public void setActuatorPrefix(String actuatorPrefix) {
 		this.actuatorPrefix = actuatorPrefix;

--- a/trampoline/src/main/java/org/ernest/applications/trampoline/entities/Microservice.java
+++ b/trampoline/src/main/java/org/ernest/applications/trampoline/entities/Microservice.java
@@ -46,7 +46,7 @@ public class Microservice {
 		this.vmArguments = vmArguments;
 	}
 	public void setActuatorPrefix(String actuatorPrefix) {
-		this.actuatorPrefix = actuatorPrefix;
+		this.actuatorPrefix = actuatorPrefix.replaceFirst("^/","");
 	}
 
 	public BuildTools getBuildTool() {


### PR DESCRIPTION
[Related issue here](https://github.com/ErnestOrt/Trampoline/issues/74)

I decided  the cleanest approach here was to add some regex in the entity setters to just strip out the '/' from any actuator prefix being added. My reasoning here was 

- Wanted to add as few code changes as possible, doing this sanitation on the client side would have touched several functions in a few js files and modifying some html too.
- Any update/create/save action is going to hit here at some point, so I know I wont miss correcting the prefix anywhere
- Stripping out the '/' keeps it simple for the user, and to the application it is unneeded as it gets prepended to the actuator prefix by the html code. _(see > instances.html, line 194)_